### PR TITLE
fix: add host transfer

### DIFF
--- a/app/sockets.py
+++ b/app/sockets.py
@@ -19,7 +19,7 @@ def _handle_user_departure(socketio, room_id, uid):
     if uid in room.current_users:
         room.remove_user(uid)
         print(f"User {uid} removed from room {room_id}.")
-        socketio.emit("user_left", {"uid": uid, "room_id": room_id}, room=room_id)
+        socketio.emit("user_left", {"uid": uid}, room=room_id)
 
         if not room.current_users: # Room became empty
             if room_id in rooms: del rooms[room_id]
@@ -35,7 +35,7 @@ def _assign_new_host(socketio, room):
         new_host_user = users.get(new_host_uid)
         new_host_username = new_host_user.username if new_host_user else "Unknown user"
         print(f"User {new_host_username} (uid: {new_host_uid}) is now the host of room {room.id}.")
-        socketio.emit("host_changed", {"room_id": room.id, "new_host_uid": new_host_uid}, room=room.id)
+        socketio.emit("host_changed", {"new_host_uid": new_host_uid}, room=room.id)
     else: # Should ideally not be reached if called after checking room.current_users
         if room.id in rooms: del rooms[room.id]
         print(f"Room {room.id} deleted as it became empty during host reassignment.")

--- a/app/sockets.py
+++ b/app/sockets.py
@@ -2,6 +2,7 @@ from flask_socketio import join_room, leave_room
 from flask import request
 from . import rooms, users
 from app.utils import find_room
+import random
 
 sid_map = {}
 uid_map = {}
@@ -15,13 +16,14 @@ def register_socket_events(socketio):
     def on_disconnect():
         print(f"Client disconnected: {request.sid}")
         uid = uid_map.pop(request.sid, None)
-        sid = sid_map.pop(uid, None)
 
         if uid:
+            sid = sid_map.pop(uid, None)
             print(f"User {uid} (SID: {request.sid}) disconnected. Cleaning up their rooms.")
 
             for room_id_key in list(rooms.keys()):
                 room = find_room(rooms, room_id_key)
+
                 if room and uid in room.current_users:
                     room.remove_user(uid)
                     print(f"User {uid} removed from room {room_id_key} due to disconnect.")
@@ -58,17 +60,25 @@ def register_socket_events(socketio):
         del uid_map[request.sid]
         leave_room(room_id)
 
+        print(f"{users[uid].username} left room {room_id}")
+        socketio.emit("user_left", {"uid": uid}, room=room_id)
+
         if find_room(rooms, room_id) != None:
             if uid in rooms[room_id].current_users:
                 rooms[room_id].current_users.remove(uid)
             if len(rooms[room_id].current_users) == 0:
                 del rooms[room_id]
                 print(f"Room {room_id} deleted due to no user")
+            elif rooms[room_id].host == uid:
+                new_host_uid = random.choice(rooms[room_id].current_users)
+                rooms[room_id].host = new_host_uid
+                new_host_uid = random.choice(rooms[room_id].current_users)
+                rooms[room_id].host = new_host_uid
+                print(f"User {users.get(new_host_uid).username} (uid: {new_host_uid}) is now the host of room {room_id}")
         else:
             print(f"Room {room_id} not found")
             
-        print(f"{users[uid].username} left room {room_id}")
-        socketio.emit("user_left", {"uid": uid}, room=room_id)
+        
 
 
     @socketio.on("send_message")

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -525,7 +525,7 @@ paths:
                 properties:
                   error:
                     type: string
-        '404':
+        "404":
           description: User not found
           content:
             application/json:
@@ -537,7 +537,7 @@ paths:
 
   /api/video/title:
     get:
-      tags: 
+      tags:
         - Videos
       summary: Get YouTube video title
       parameters:
@@ -549,7 +549,7 @@ paths:
             type: string
             example: ZEcqHA7dbwM
       responses:
-        '200':
+        "200":
           description: YouTube video title returned
           content:
             application/json:
@@ -559,7 +559,7 @@ paths:
                   title:
                     type: string
                     example: Fly Me To The Moon (2008 Remastered)
-        '400':
+        "400":
           description: Missing YouTube video ID
           content:
             application/json:
@@ -568,7 +568,7 @@ paths:
                 properties:
                   error:
                     type: string
-        '404':
+        "404":
           description: Video not found
           content:
             application/json:
@@ -577,7 +577,7 @@ paths:
                 properties:
                   error:
                     type: string
-        '500':
+        "500":
           description: Failed to fetch video data or YouTube API key not configured
           content:
             application/json:


### PR DESCRIPTION
Closes #30.

The additions are two helper functions:
- `_handle_user_departure`
	- Removes user from the room
	- If empty, deletes the room
	- If the host disconnected, reassigns it through `_assign_new_host`
- `_assign_new_host`
	- Randomly chooses a new host 

I made them into helper functions to avoid redundancy. The `_handle_user_departure` function needs to be called in two cases:
- When the user disconnects abruptly (`disconnect`)
- When the user leaves the room explicitly (`leave_room`)

To avoid repeating the code in these two sockets, I thought it would be better to wrap them up as functions.