### PR TITLE
Refactor: Use logging instead of print statements (#32)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 __pycache__
 
 env.py
+venv/
+.env/
+ENV/
+env/
+logs/
+*.log

--- a/app/logger_config.py
+++ b/app/logger_config.py
@@ -1,0 +1,32 @@
+import logging
+from logging.handlers import RotatingFileHandler
+import os
+
+LOG_DIR = 'logs'
+LOG_FILE = 'app.log'
+os.makedirs(LOG_DIR, exist_ok=True) 
+
+formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(name)s - %(message)s")
+
+def get_logger(name: str) -> logging.Logger:
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.INFO)
+
+
+    if not logger.handlers:
+        console_handler = logging.StreamHandler()
+        console_handler.setLevel(logging.INFO)
+        console_handler.setFormatter(formatter)
+
+        file_handler = RotatingFileHandler(
+            os.path.join(LOG_DIR, LOG_FILE),
+            maxBytes=5 * 1024 * 1024,
+            backupCount=3
+        )
+        file_handler.setLevel(logging.INFO)
+        file_handler.setFormatter(formatter)
+
+        logger.addHandler(console_handler)
+        logger.addHandler(file_handler)
+
+    return logger

--- a/app/routes.py
+++ b/app/routes.py
@@ -34,7 +34,7 @@ def createroom():
     rooms[next_room_id] = Room(data, id=next_room_id)
     next_room_id += 1
 
-    logger.info("Room created successfully.")
+    logger.info(f"Room created successfully. Room ID: {next_room_id - 1}, Host UID: {data.get('host')}")
     return jsonify({"id": (next_room_id - 1)}), 201
 
 
@@ -57,7 +57,7 @@ def updatesettings():
 
     rooms[id].update_settings(data)
 
-    logger.info("Room updated successfully.")
+    logger.info(f"Room settings updated. Room ID: {id}, Updated Fields: {data}")
     return jsonify({"message": "Room updated successfully"}), 200
 
 # Retrieve available public rooms
@@ -160,7 +160,7 @@ def create_user():
     uid = str(uuid.uuid4())
     users[uid] = User(username, uid)
 
-    logger.info("User created successfully.")
+    logger.info(f"User created successfully. Username: {username}, UID: {uid}")
     return jsonify({"uid": (uid)}), 201
 
 
@@ -180,7 +180,7 @@ def update_username():
     else:
         return jsonify({"error": "User not found"}), 404
 
-    logger.info("Username updated successfully.")
+    logger.info(f"Username updated successfully. UID: {uid}, New Username: {username}")
     return jsonify({"message": "Username updated successfully"}), 200
 
 # User info

--- a/app/routes.py
+++ b/app/routes.py
@@ -7,7 +7,9 @@ import uuid
 import requests 
 import os
 from env import YOUTUBE_API_KEY
+from app.logger_config import get_logger
 
+logger = get_logger(__name__)
 from . import rooms, users
 next_room_id = 1 # id is just a counter now
 
@@ -32,7 +34,7 @@ def createroom():
     rooms[next_room_id] = Room(data, id=next_room_id)
     next_room_id += 1
 
-    print("Room created successfully.") # testing purposes
+    logger.info("Room created successfully.")
     return jsonify({"id": (next_room_id - 1)}), 201
 
 
@@ -55,7 +57,7 @@ def updatesettings():
 
     rooms[id].update_settings(data)
 
-    print("Room updated successfully.") # testing purposes
+    logger.info("Room updated successfully.")
     return jsonify({"message": "Room updated successfully"}), 200
 
 # Retrieve available public rooms
@@ -158,7 +160,7 @@ def create_user():
     uid = str(uuid.uuid4())
     users[uid] = User(username, uid)
 
-    print("User created successfully.") # testing purposes
+    logger.info("User created successfully.")
     return jsonify({"uid": (uid)}), 201
 
 
@@ -178,7 +180,7 @@ def update_username():
     else:
         return jsonify({"error": "User not found"}), 404
 
-    print("Username updated successfully.") # testing purposes
+    logger.info("Username updated successfully.")
     return jsonify({"message": "Username updated successfully"}), 200
 
 # User info

--- a/app/sockets.py
+++ b/app/sockets.py
@@ -131,5 +131,5 @@ def register_socket_events(socketio):
             case "ping":
                 socketio.emit("pong", {}, to=request.sid)
             case _:
-                logger.warning("Wrong control signal")
+                logger.warning(f"Invalid control signal received: '{message_type}' from SID: {request.sid} in Room ID: {room_id}")
 

--- a/app/sockets.py
+++ b/app/sockets.py
@@ -3,7 +3,9 @@ from flask import request
 from . import rooms, users
 from app.utils import find_room
 import random
+from app.logger_config import get_logger
 
+logger = get_logger(__name__)
 sid_map = {}
 uid_map = {}
 
@@ -13,17 +15,17 @@ def _handle_user_departure(socketio, room_id, uid):
     """Helper function to manage room state when a user departs."""
     room = find_room(rooms, room_id)
     if not room:
-        print(f"Room {room_id} not found during user {uid} departure.")
+        logger.warning(f"Room {room_id} not found during user {uid} departure.")
         return
 
     if uid in room.current_users:
         room.remove_user(uid)
-        print(f"User {uid} removed from room {room_id}.")
+        logger.info(f"User {uid} removed from room {room_id}.")
         socketio.emit("user_left", {"uid": uid}, room=room_id)
 
         if not room.current_users: # Room became empty
             if room_id in rooms: del rooms[room_id]
-            print(f"Room {room_id} deleted as it became empty.")
+            logger.info(f"Room {room_id} deleted as it became empty.")
         elif room.host == uid: # Room not empty, and departing user was host
             _assign_new_host(socketio, room)
 
@@ -34,27 +36,27 @@ def _assign_new_host(socketio, room):
         room.host = new_host_uid
         new_host_user = users.get(new_host_uid)
         new_host_username = new_host_user.username if new_host_user else "Unknown user"
-        print(f"User {new_host_username} (uid: {new_host_uid}) is now the host of room {room.id}.")
+        logger.info(f"User {new_host_username} (uid: {new_host_uid}) is now the host of room {room.id}.")
         socketio.emit("host_changed", {"new_host_uid": new_host_uid}, room=room.id)
     else: # Should ideally not be reached if called after checking room.current_users
         if room.id in rooms: del rooms[room.id]
-        print(f"Room {room.id} deleted as it became empty during host reassignment.")
+        logger.info(f"Room {room.id} deleted as it became empty during host reassignment.")
 
 # ===== SOCKETS =====
 
 def register_socket_events(socketio):
     @socketio.on("connect")
     def on_connect():
-        print(f"Client connected: sid={request.sid}")
+        logger.info(f"Client connected: sid={request.sid}")
 
     @socketio.on("disconnect")
     def on_disconnect():
-        print(f"Client disconnected: {request.sid}")
+        logger.info(f"Client disconnected: {request.sid}")
         uid = uid_map.pop(request.sid, None)
 
         if uid:
             sid = sid_map.pop(uid, None)
-            print(f"User {uid} (SID: {request.sid}) disconnected. Cleaning up their rooms.")
+            logger.info(f"User {uid} (SID: {request.sid}) disconnected. Cleaning up their rooms.")
 
             for room_id_key in list(rooms.keys()):
                 room = find_room(rooms, room_id_key)
@@ -62,7 +64,7 @@ def register_socket_events(socketio):
                 if room and uid in room.current_users:
                     _handle_user_departure(socketio, room_id_key, uid)
         else:
-            print(f"SID {request.sid} disconnected, no user mapping found or already cleaned up.")
+            logger.info(f"SID {request.sid} disconnected, no user mapping found or already cleaned up.")
 
     @socketio.on("join_room")
     def on_join(data):
@@ -76,9 +78,9 @@ def register_socket_events(socketio):
             if uid not in rooms[room_id].current_users:
                 rooms[room_id].current_users.append(uid)
         else:
-            print(f"Room {room_id} not found")
+            logger.warning(f"Room {room_id} not found")
 
-        print(f"{users[uid].username} joined room {room_id}")
+        logger.info(f"{users[uid].username} joined room {room_id}")
         socketio.emit("user_joined", {"uid": uid}, room=room_id)
 
     @socketio.on("leave_room")
@@ -89,7 +91,7 @@ def register_socket_events(socketio):
         del uid_map[request.sid]
         leave_room(room_id)
 
-        print(f"{users[uid].username} left room {room_id}")
+        logger.info(f"{users[uid].username} left room {room_id}")
         _handle_user_departure(socketio, room_id, uid)
             
         
@@ -99,7 +101,7 @@ def register_socket_events(socketio):
     def on_message(data):
         room_id = int(data.get("room_id"))
         message_type = data.get("message_type")
-        print(f"sent {message_type} from {room_id}")
+        logger.info(f"sent {message_type} from {room_id}")
 
         match message_type:
             case "msg":
@@ -121,12 +123,13 @@ def register_socket_events(socketio):
                 rooms[room_id].queue.append(video)
                 socketio.emit("broadcast_add", {"video": video}, room=room_id, include_self=False)
             case "skip":
-                print(rooms[room_id].queue[0])
+                logger.info(f"Skipping video: {rooms[room_id].queue[0]}")
                 rooms[room_id].current_song = rooms[room_id].queue[0]
-                print(rooms[room_id].current_song)
+                logger.info(f"Current song updated to: {rooms[room_id].current_song}")
                 rooms[room_id].queue.pop(0)
                 socketio.emit("broadcast_skip", {}, room=room_id, include_self=False)
             case "ping":
                 socketio.emit("pong", {}, to=request.sid)
             case _:
-                print("Wrong control signal")
+                logger.warning("Wrong control signal")
+


### PR DESCRIPTION
## What I Did
- Replaced all `print()` statements in `routes.py` and `sockets.py` with calls to `get_logger(__name__)`
- Centralized logging configuration in `logger_config.py` with support for file and console output
- Ensured logging works for room/user events and socket actions

## Why
This improves log consistency, makes logs easier to debug in production, and resolves #32.

## How to Test
- Run the dev server and create/join/leave rooms
- Observe logs in the terminal and in `logs/app.log`
