### PR TITLE
fix: Fix wrong variable reference in room deletion

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -81,7 +81,7 @@ def deleteroom():
         room_id = int(request.args.get('room_id'))
         uid = request.args.get('uid')
     except ValueError:
-        return jsonify({"message": "Query parameter 'id' must be an integer"}), 400
+        return jsonify({"message": "Query parameter 'room_id' must be an integer"}), 400
 
     room_to_delete = find_room(rooms, room_id)
     
@@ -90,8 +90,8 @@ def deleteroom():
         if room_to_delete.host != uid:
             return jsonify({"message": "User not host, cannot delete room"}), 400
         
-        rooms[id].current_users.clear()
-        del rooms[id]
+        rooms[room_id].current_users.clear()
+        del rooms[room_id]
         return jsonify({"message": "Room deleted successfully"}), 200
     else:
         return jsonify({"message": "Room not found"}), 404


### PR DESCRIPTION
- Fixed 'id' to 'room_id' in /api/room/deleteroom route
- Prevents 500 error and ensures room deletes correctly close #37

# New Pull Request

## Description

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
	- Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
	- when request to delete room, the server response with 500 http status code.
	- below is the related issue.
	- #37 

- **What is the new behavior (if this is a feature change)?**

- **Other information**:

## Check-List

1. [x] I have tested and performed a self-review of my code
2. [x] I have followed the guidelines in the Contributing document
3. [x] I have checked there aren't other open [Pull Requests](../../../pulls) for the same update/change

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #37 
