### PR TITLE
Feat: support batch adding songs from YouTube playlist

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -8,7 +8,6 @@ import requests
 import os
 from env import YOUTUBE_API_KEY
 from app.logger_config import get_logger
-from yt_dlp import YoutubeDL
 
 logger = get_logger(__name__)
 from . import rooms, users
@@ -229,29 +228,36 @@ def get_youtube_title():
 
 @api_bp.route("/playlist/fetch", methods=["POST"])
 def fetch_playlist():
-
     data = request.get_json()
-    url = data.get("url")
+    playlist_id = data.get("playlistId")
+    if not playlist_id:
+        return jsonify({"error": "Missing playlistId"}), 400
 
-    if not url:
-        return jsonify({"error": "No playlist URL provided"}), 400
+    url = (
+        f"https://www.googleapis.com/youtube/v3/playlistItems"
+        f"?part=snippet&maxResults=50&playlistId={playlist_id}&key={YOUTUBE_API_KEY}"
+    )
+    items = []
 
-    ydl_opts = {
-        'quiet': True,
-        'extract_flat': True,
-        'force_generic_extractor': True,
-    }
+    while url:
+        res = requests.get(url)
+        if res.status_code != 200:
+            return jsonify({"error": "Failed to fetch playlist items"}), 500
+        data = res.json()
+        for item in data.get("items", []):
+            snippet = item["snippet"]
+            title = snippet.get("title", "")
+            if title.strip() in ["Deleted video", "Private video"]:
+                continue
+            video_id = snippet["resourceId"]["videoId"]
+            items.append({"title": snippet["title"], "youtube_id": video_id})
+        token = data.get("nextPageToken")
+        if token:
+            url = (
+                f"https://www.googleapis.com/youtube/v3/playlistItems"
+                f"?part=snippet&maxResults=50&playlistId={playlist_id}&pageToken={token}&key={YOUTUBE_API_KEY}"
+            )
+        else:
+            break
 
-    try:
-        with YoutubeDL(ydl_opts) as ydl:
-            info_dict = ydl.extract_info(url, download=False)
-            entries = info_dict.get('entries', [])
-            result = [
-                {
-                    "title": entry.get("title"),
-                    "youtube_id": entry.get("id")
-                } for entry in entries if entry.get("id")
-            ]
-        return jsonify({"videos": result}), 200
-    except Exception as e:
-        return jsonify({"error": str(e)}), 500
+    return jsonify({"videos": items}), 200

--- a/app/routes.py
+++ b/app/routes.py
@@ -226,10 +226,9 @@ def get_youtube_title():
     title = items[0]["snippet"]["title"]
     return jsonify({"title": title}), 200
 
-@api_bp.route("/playlist/fetch", methods=["POST"])
+@api_bp.route("/video/getplaylist", methods=["GET"])
 def fetch_playlist():
-    data = request.get_json()
-    playlist_id = data.get("playlistId")
+    playlist_id = request.args.get("playlistid")
     if not playlist_id:
         return jsonify({"error": "Missing playlistId"}), 400
 

--- a/app/sockets.py
+++ b/app/sockets.py
@@ -111,6 +111,11 @@ def register_socket_events(socketio):
                 socketio.emit("broadcast_play", {}, room=room_id, include_self=False)
             case "pause":
                 socketio.emit("broadcast_pause", {}, room=room_id, include_self=False)
+            case "add_playlist":
+                videos = data.get("videos")  # List of {title, youtube_id, added_by}
+                for video in videos:
+                    rooms[room_id].queue.append(video)
+                socketio.emit("broadcast_add_playlist", {"videos": videos}, room=room_id, include_self=False)
             case "sync":
                 timestamp = data.get("timestamp");
                 socketio.emit("broadcast_sync", {"timestamp": timestamp}, room=room_id, include_self=False)
@@ -132,4 +137,5 @@ def register_socket_events(socketio):
                 socketio.emit("pong", {}, to=request.sid)
             case _:
                 logger.warning(f"Invalid control signal received: '{message_type}' from SID: {request.sid} in Room ID: {room_id}")
+                
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -586,3 +586,53 @@ paths:
                 properties:
                   error:
                     type: string
+  /api/video/getplaylist:
+    get:
+      tags:
+        - Videos
+      summary: Fetch YouTube playlist videos
+      description: Returns a list of video titles and IDs from a given YouTube playlist.
+      parameters:
+        - name: playlistid
+          in: query
+          required: true
+          description: The ID of the YouTube playlist to fetch.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: A list of videos in the playlist
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  videos:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        title:
+                          type: string
+                          description: The title of the video
+                        youtube_id:
+                          type: string
+                          description: The YouTube video ID
+        "400":
+          description: Bad request - missing or invalid playlistid parameter
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+        "500":
+          description: Internal server error - failed to fetch playlist items
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ flask-socketio
 Flask-CORS
 gunicorn
 requests
-yt_dlp

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ flask-socketio
 Flask-CORS
 gunicorn
 requests
+yt_dlp


### PR DESCRIPTION
# New Pull Request


## Description

- **What kind of change does this PR introduce?** 
Feature: Add support for importing YouTube playlists (backend)

- **What is the current behavior?** 
#33 
Users can only add one YouTube video at a time using a video ID.

- **What is the new behavior (if this is a feature change)?**
Users can now paste a YouTube playlist URL. The backend fetches the list of videos from the playlist using yt_dlp, and returns their title and youtube_id to the frontend.
This allows for batch-adding multiple songs at once via socket message "add_playlist".

- **Other information**:
1. Added 'yt_dlp' to requirements.txt to support playlist extraction.
2. No YouTube API key required for this functionality.

## Check-List

1. [x] I have tested and performed a self-review of my code
2. [x] I have followed the guidelines in the Contributing document
3. [x] I have checked there aren't other open [Pull Requests](../../../pulls) for the same update/change

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #33 
